### PR TITLE
Fix segfault, EOL bug and pass on env variables in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,26 @@
-CC = gcc
 TARGET = tsschecker_tool
-LD_FLAGS = -L/usr/local/lib -L/opt/local/lib -lplist -lpartialzip-1.0 -lz -lcurl -lcrippy-1.0 -lxml2 -lm
+LDFLAGS += -lplist -lpartialzip-1.0 -lz -lcurl -lcrippy-1.0 -lxml2 -lm
 
 all : $(TARGET)
 
 tsschecker_tool : tsschecker/main.o tsschecker/download.o tsschecker/jsmn.o tsschecker/tss.o tsschecker/tsschecker.o
-		$(CC) tsschecker/main.o tsschecker/download.o tsschecker/jsmn.o tsschecker/tss.o tsschecker/tsschecker.o $(LD_FLAGS) -o $(TARGET)
+		$(CC) $(CFLAGS) tsschecker/main.o tsschecker/download.o tsschecker/jsmn.o tsschecker/tss.o tsschecker/tsschecker.o $(LDFLAGS) -o $(TARGET)
 		@echo "Successfully built $(TARGET)"
 
 main.o : tsschecker/main.c
-		$(CC) -c tsschecker/main.c -o tsschecker/main.o
+		$(CC) $(CFLAGS) -c tsschecker/main.c -o tsschecker/main.o
 
 download.o : tsschecker/download.c 
-		$(CC) -c tsschecker/download.c -o tsschecker/download.o
+		$(CC) $(CFLAGS) -c tsschecker/download.c -o tsschecker/download.o
 
 jsmn.o : tsschecker/jsmn.c
-		$(CC) -c tsschecker/jsmn.c -o tsschecker/jsmn.o
+		$(CC) $(CFLAGS) -c tsschecker/jsmn.c -o tsschecker/jsmn.o
 
 tss.o : tsschecker/tss.c
-		$(CC) -c tsschecker/tss.c -o tsschecker/tss.o
+		$(CC) $(CFLAGS) -c tsschecker/tss.c -o tsschecker/tss.o
 
 tsschecker.o :
-		$(CC) -c tsschecker/tsschecker.c -o tsschecker/tsschecker.o
+		$(CC) $(CFLAGS) -c tsschecker/tsschecker.c -o tsschecker/tsschecker.o
 
 install :
 		cp $(TARGET) /usr/local/bin/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 TARGET = tsschecker_tool
+CFLAGS += -Wall
 LDFLAGS += -lplist -lpartialzip-1.0 -lz -lcurl -lcrippy-1.0 -lxml2 -lm
 
 all : $(TARGET)

--- a/tsschecker/tss.c
+++ b/tsschecker/tss.c
@@ -761,9 +761,12 @@ plist_t tss_request_send(plist_t tss_request, const char* server_url_string) {
 	
 		if (strstr(response->content, "MESSAGE=SUCCESS")) {
 			status_code = 0;
-			info("response successfully received\n");
+			info("success\n");
 			break;
 		}
+        else {
+            info("failure\n");
+        }
 
 		if (response->length > 0) {
 			error("TSS server returned: %s\n", response->content);

--- a/tsschecker/tsschecker.c
+++ b/tsschecker/tsschecker.c
@@ -420,7 +420,7 @@ int isManifestBufSignedForDevice(char *buildManifestBuffer, char *device, t_devi
     
     
     if (print_tss_response) debug_plist(apticket);
-    if (save_shshblobs){
+    if (isSigned && save_shshblobs){
         plist_t manifest = 0;
         plist_from_xml(buildManifestBuffer, (unsigned)strlen(buildManifestBuffer), &manifest);
         plist_t build = plist_dict_get_item(manifest, "ProductBuildVersion");


### PR DESCRIPTION
* Fix segfault when trying to save shsh blobs on firmwares no longer being signed
* Fix missing EOL with unsuccessful TSS response
* Make Makefile more flexible:
  * Pass on environment variables
  * Use standard names (LD_FLAGS -> LDFLAGS)
  * Enable all warnings by default
  * Don't assume anything about build environment (no `-L` flags and don't assume gcc)