### PR TITLE
Disable libcrypto on Mac by default

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e;
+
 gprefix=`which glibtoolize 2>&1 >/dev/null`
 if [ $? -eq 0 ]; then
   glibtoolize --force

--- a/configure.ac
+++ b/configure.ac
@@ -12,6 +12,8 @@ CFLAGS+=" -std=c11"
 AC_PROG_INSTALL
 AC_PROG_LIBTOOL
 
+AC_CONFIG_MACRO_DIRS([m4])
+
 # Checks for libraries.
 
 PKG_CHECK_MODULES(libplist, libplist >= 1.0)

--- a/configure.ac
+++ b/configure.ac
@@ -16,10 +16,30 @@ AC_CONFIG_MACRO_DIRS([m4])
 
 # Checks for libraries.
 
+AC_CANONICAL_HOST
+
+AC_ARG_WITH(
+    [libcrypto],
+    [AS_HELP_STRING([--with-libcrypto], [build with libcrypto (default for non-Mac)])],
+    [],
+    [
+        case "${host_os}" in
+            darwin*)
+                with_libcrypto=no
+                ;;
+            *)
+                with_libcrypto=yes
+                ;;
+        esac
+    ]
+)
+
 PKG_CHECK_MODULES(libplist, libplist >= 1.0)
 PKG_CHECK_MODULES(libcurl, libcurl >= 1.0)
 PKG_CHECK_MODULES(libfragmentzip, libfragmentzip >= 1.0)
-PKG_CHECK_MODULES(libcrypto, libcrypto >= 1.0)
+AS_IF([test "x$with_libcrypto" != xno],
+    [PKG_CHECK_MODULES(libcrypto, libcrypto >= 1.0)]
+)
 PKG_CHECK_MODULES(libirecovery, libirecovery >= 0.2.0)
 
 


### PR DESCRIPTION
CommonCrypto removes the need for libcrypto on Mac.

Also, minor changes:
- Make `autogen.sh` fail fast
- Explicitly require the `m4` directory in `configure.ac`