### PR TITLE
Add iPad 5,3 with no Baseband

### DIFF
--- a/tsschecker/tsschecker.c
+++ b/tsschecker/tsschecker.c
@@ -145,6 +145,7 @@ static struct bbdevice bbdevices[] = {
     {"iPad4,1", 0},
     {"iPad4,2", 3554301762},
     {"iPad4,4", 0},
+    {"iPad5,3", 0},
     {"iPad5,4", 3840149528},
     {"iPad6,3", 0},
     {"iPad6,7", 0},


### PR DESCRIPTION
iPad5,3 is the Wifi only iPad Air 2