### PR TITLE
Fix crash when Device Model is invalid

### DIFF
--- a/tsschecker/tsschecker.c
+++ b/tsschecker/tsschecker.c
@@ -348,6 +348,9 @@ t_versionURL *getFirmwareUrls(const char *deviceModel, t_iosVersion *versVals, c
     jsmntok_t *firmwares = getFirmwaresForDevice(deviceModel, firmwarejson, tokens, versVals->isOta);
     const char *versstring = (versVals->buildID) ? versVals->buildID : versVals->version;
     
+    if (!firmwares)
+        return error("[TSSC] device '%s' could not be found in devicelist\n", deviceModel), NULL;
+    
 malloc_rets:
     if (retcounter)
         memset(rets = (t_versionURL*)malloc(sizeof(t_versionURL)*(retcounter+1)), 0, sizeof(t_versionURL)*(retcounter+1));


### PR DESCRIPTION
Giving invalid device model segfaults:
```sh
$ ./tsschecker -d "typo" -i 10.2.1
Version: 29635e38dab3f18061677b20d2196f391eb1e243 - 183
[TSSC] opening firmware.json
[JSON] counting elements
[JSON] parsing elements
[1]    23238 segmentation fault  ./tsschecker -d "typo" -i 10.2.1
```
After fix (error message could be better though):
```sh
$ ./tsschecker -d "typo" -i 10.2.1
Version: 29635e38dab3f18061677b20d2196f391eb1e243 - 183
[TSSC] opening firmware.json
[JSON] counting elements
[JSON] parsing elements
[Error] [TSSC] device 'Typo' could not be found in devicelist
[Error] [TSSC] ERROR: could not get url for device Typo on iOS 10.2.1

iOS 10.2.1 for device Typo IS NOT being signed!
```