### PR TITLE
Update nonceLen for A10X/A11 devices

### DIFF
--- a/tsschecker/tsschecker.c
+++ b/tsschecker/tsschecker.c
@@ -615,8 +615,9 @@ int tss_populate_random(plist_t tssreq, int is64bit, t_devicevals *devVals){
     size_t nonceLen = 20; //valid for all devices up to iPhone7
     if (!devVals->deviceModel)
         return error("[TSSR] internal error: devVals->deviceModel is missing\n"),-1;
-    
-    if (strncasecmp(devVals->deviceModel, "iPhone9,", strlen("iPhone9,")) == 0)
+
+    if (strncasecmp(devVals->deviceModel, "iPhone9,", strlen("iPhone9,")) == 0 ||
+            strncasecmp(devVals->deviceModel, "iPhone10,", strlen("iPhone10,")) == 0)
         nonceLen = 32;
     
     int n=0;

--- a/tsschecker/tsschecker.c
+++ b/tsschecker/tsschecker.c
@@ -617,9 +617,11 @@ int tss_populate_random(plist_t tssreq, int is64bit, t_devicevals *devVals){
         return error("[TSSR] internal error: devVals->deviceModel is missing\n"),-1;
 
     if (strncasecmp(devVals->deviceModel, "iPhone9,", strlen("iPhone9,")) == 0 ||
-            strncasecmp(devVals->deviceModel, "iPhone10,", strlen("iPhone10,")) == 0)
+            strncasecmp(devVals->deviceModel, "iPhone10,", strlen("iPhone10,")) == 0 ||
+            strncasecmp(devVals->deviceModel, "iPad7,", strlen("iPad7,")) == 0 ||
+            strncasecmp(devVals->deviceModel, "AppleTV6,", strlen("AppleTV6,")) == 0)
         nonceLen = 32;
-    
+
     int n=0;
     srand((unsigned int)time(NULL));
     if (!devVals->ecid) for (int i=0; i<16; i++) devVals->ecid += (rand() % 10) * pow(10, n++);


### PR DESCRIPTION
Fixes BNCH size in saved SHSH blobs for iPhone 8 & X.

It seems like this logic should be more generic, however I'm not sure how else to determine the desired nonce length here.

It may also be useful to run the returned blob through img4tool's validate check before saving.

Updates to img4tool's validation here: tihmstar/img4tool#5