### PR TITLE
Fix incorrect language standard

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@ esac
 
 # Checks for programs.
 AC_PROG_CC
-CFLAGS+=" -std=c11"
+CFLAGS+=" -std=gnu11"
 AC_PROG_INSTALL
 AC_PROG_LIBTOOL
 AC_CONFIG_MACRO_DIRS([m4])


### PR DESCRIPTION
This project uses `strdup`, which is a POSIX extension. Compiling with `-std=c11` (using GCC 9.2.0 on Arch Linux), which doesn't support this function, causes the following warnings:
```
tss.c: In function ‘tss_request_add_savage_tags’:
tss.c:1148:27: warning: implicit declaration of function ‘strdup’; did you mean ‘strcmp’? [-Wimplicit-function-declaration]
 1148 |         *component_name = strdup(comp_name);
      |                           ^~~~~~
      |                           strcmp
tss.c:1148:25: warning: assignment to ‘char *’ from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
 1148 |         *component_name = strdup(comp_name);
      |                         ^
```
To fix this, change `-std=c11` to `-std=gnu11`.