### PR TITLE
Fix cross compiling for Windows/Mingw

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -63,9 +63,7 @@ AC_TYPE_UINT8_T
 
 # Checks for library functions.
 AC_FUNC_ERROR_AT_LINE
-AC_FUNC_MALLOC
-AC_FUNC_REALLOC
-AC_CHECK_FUNCS([memset mkdir pow strchr strdup strstr])
+AC_CHECK_FUNCS([memset mkdir pow strchr strdup strstr malloc realloc])
 
 case $CFLAGS in
   *TSSCHECKER_NOMAIN*)


### PR DESCRIPTION
Cross compiling from Linux/macOS to Windows causes `AC_FUNC_MALLOC` and `AC_FUNC_REALLOC` to fail during configure and defines malloc and realloc as `rpl_malloc` and `rpl_realloc`, which then causes linking to fail.

This fix uses `AC_CHECK_FUNCS` to check for `malloc` and `realloc` instead.