### PR TITLE
Update libplist and libirecovery names for 2.2.0/1.0.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -42,13 +42,13 @@ AC_ARG_WITH(
     ]
 )
 
-PKG_CHECK_MODULES(libplist, libplist >= 2.0.0)
+PKG_CHECK_MODULES(libplist, libplist-2.0 >= 2.2.0)
 PKG_CHECK_MODULES(libcurl, libcurl >= 1.0)
 PKG_CHECK_MODULES(libfragmentzip, libfragmentzip >= 48)
 AS_IF([test "x$with_libcrypto" != xno],
     [PKG_CHECK_MODULES(libcrypto, libcrypto >= 1.0)]
 )
-PKG_CHECK_MODULES(libirecovery, libirecovery >= 0.2.0)
+PKG_CHECK_MODULES(libirecovery, libirecovery-1.0 >= 1.0.0)
 
 # Checks for header files.
 AC_CHECK_HEADERS([getopt.h stddef.h stdio.h])


### PR DESCRIPTION
Version 2.2.0 of libplist and version 1.0.0 of libirecovery changed the library names from `libplist` to `libplist-2.0` and from `libirecovery` to `libirecovery-1.0`, respectively, which causes tsschecker to not find the libraries. This patch fixes that.